### PR TITLE
Fetch feed posts

### DIFF
--- a/Zstagram.xcodeproj/project.pbxproj
+++ b/Zstagram.xcodeproj/project.pbxproj
@@ -155,6 +155,23 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		AF337B942A8C187C00D0D4FC /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				AF337B962A8C18A100D0D4FC /* FeedViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		AF337B952A8C188100D0D4FC /* View */ = {
+			isa = PBXGroup;
+			children = (
+				AF5851EC2A7163B60011C875 /* FeedListView.swift */,
+				AF5851EA2A71635E0011C875 /* FeedView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		AFCDCC122A70850E00E23F0B /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -336,8 +353,8 @@
 		AFFFF12C2A7008150090E868 /* Feed */ = {
 			isa = PBXGroup;
 			children = (
-				AF5851EC2A7163B60011C875 /* FeedListView.swift */,
-				AF5851EA2A71635E0011C875 /* FeedView.swift */,
+				AF337B952A8C188100D0D4FC /* View */,
+				AF337B942A8C187C00D0D4FC /* ViewModel */,
 			);
 			path = Feed;
 			sourceTree = "<group>";

--- a/Zstagram.xcodeproj/project.pbxproj
+++ b/Zstagram.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AF337B8D2A8BF25400D0D4FC /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = AF337B8C2A8BF25400D0D4FC /* Kingfisher */; };
 		AF337B8F2A8BF2BB00D0D4FC /* CircularProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF337B8E2A8BF2BB00D0D4FC /* CircularProfileImageView.swift */; };
 		AF337B912A8C008200D0D4FC /* ImageModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF337B902A8C008200D0D4FC /* ImageModifier.swift */; };
+		AF337B992A8C190C00D0D4FC /* PostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF337B982A8C190C00D0D4FC /* PostService.swift */; };
 		AF4718832A7FDFB8000288F9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AF4718822A7FDFB8000288F9 /* GoogleService-Info.plist */; };
 		AF4718862A7FE092000288F9 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = AF4718852A7FE092000288F9 /* FirebaseAnalytics */; };
 		AF4718882A7FE092000288F9 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = AF4718872A7FE092000288F9 /* FirebaseAuth */; };
@@ -66,6 +67,7 @@
 		AF337B892A8BDEBA00D0D4FC /* ImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploader.swift; sourceTree = "<group>"; };
 		AF337B8E2A8BF2BB00D0D4FC /* CircularProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProfileImageView.swift; sourceTree = "<group>"; };
 		AF337B902A8C008200D0D4FC /* ImageModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageModifier.swift; sourceTree = "<group>"; };
+		AF337B982A8C190C00D0D4FC /* PostService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostService.swift; sourceTree = "<group>"; };
 		AF4718822A7FDFB8000288F9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		AF5851EA2A71635E0011C875 /* FeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedView.swift; sourceTree = "<group>"; };
 		AF5851EC2A7163B60011C875 /* FeedListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedListView.swift; sourceTree = "<group>"; };
@@ -312,8 +314,9 @@
 		AFFFF12A2A7005990090E868 /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				AFD681372A8ACE61006C4C93 /* UserService.swift */,
 				AF337B892A8BDEBA00D0D4FC /* ImageUploader.swift */,
+				AFD681372A8ACE61006C4C93 /* UserService.swift */,
+				AF337B982A8C190C00D0D4FC /* PostService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -473,6 +476,7 @@
 				AFCDCC162A70856C00E23F0B /* UserStateView.swift in Sources */,
 				AFD183B72A8A5E8900A08ED7 /* ContentViewModel.swift in Sources */,
 				AF337B912A8C008200D0D4FC /* ImageModifier.swift in Sources */,
+				AF337B992A8C190C00D0D4FC /* PostService.swift in Sources */,
 				AF337B8A2A8BDEBA00D0D4FC /* ImageUploader.swift in Sources */,
 				AF599F3C2A72D8A800CC004C /* UserImageView.swift in Sources */,
 				AF337B842A8BCAC500D0D4FC /* EditProfileRowView.swift in Sources */,

--- a/Zstagram.xcodeproj/project.pbxproj
+++ b/Zstagram.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AF337B8D2A8BF25400D0D4FC /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = AF337B8C2A8BF25400D0D4FC /* Kingfisher */; };
 		AF337B8F2A8BF2BB00D0D4FC /* CircularProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF337B8E2A8BF2BB00D0D4FC /* CircularProfileImageView.swift */; };
 		AF337B912A8C008200D0D4FC /* ImageModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF337B902A8C008200D0D4FC /* ImageModifier.swift */; };
+		AF337B972A8C18A100D0D4FC /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF337B962A8C18A100D0D4FC /* FeedViewModel.swift */; };
 		AF337B992A8C190C00D0D4FC /* PostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF337B982A8C190C00D0D4FC /* PostService.swift */; };
 		AF4718832A7FDFB8000288F9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AF4718822A7FDFB8000288F9 /* GoogleService-Info.plist */; };
 		AF4718862A7FE092000288F9 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = AF4718852A7FE092000288F9 /* FirebaseAnalytics */; };
@@ -67,6 +68,7 @@
 		AF337B892A8BDEBA00D0D4FC /* ImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploader.swift; sourceTree = "<group>"; };
 		AF337B8E2A8BF2BB00D0D4FC /* CircularProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProfileImageView.swift; sourceTree = "<group>"; };
 		AF337B902A8C008200D0D4FC /* ImageModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageModifier.swift; sourceTree = "<group>"; };
+		AF337B962A8C18A100D0D4FC /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
 		AF337B982A8C190C00D0D4FC /* PostService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostService.swift; sourceTree = "<group>"; };
 		AF4718822A7FDFB8000288F9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		AF5851EA2A71635E0011C875 /* FeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedView.swift; sourceTree = "<group>"; };
@@ -467,6 +469,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF337B972A8C18A100D0D4FC /* FeedViewModel.swift in Sources */,
 				AF60985F2A7C04EA00BF8C1D /* Post.swift in Sources */,
 				AF337B8F2A8BF2BB00D0D4FC /* CircularProfileImageView.swift in Sources */,
 				AF6848BB2A7321D700C5292E /* SearchView.swift in Sources */,

--- a/Zstagram/Core/Authentication/Service/AuthService.swift
+++ b/Zstagram/Core/Authentication/Service/AuthService.swift
@@ -58,9 +58,7 @@ class AuthService {
     func loadUserData() async throws {
         self.userSession = Auth.auth().currentUser
         guard let currentUId = userSession?.uid else { return }
-        let snapshot = try await Firestore.firestore().collection("users").document(currentUId).getDocument()
-        print("DEBUG: Snapshot data is \(snapshot.data() ?? [:])")
-        self.currentUser = try? snapshot.data(as: User.self)
+        self.currentUser = try await UserService.fetchUser(withCurrentUId: currentUId)
     }
     
     func signout() {

--- a/Zstagram/Core/Feed/View/FeedListView.swift
+++ b/Zstagram/Core/Feed/View/FeedListView.swift
@@ -8,11 +8,14 @@
 import SwiftUI
 
 struct FeedListView: View {
+    
+    @StateObject var viewModel = FeedViewModel()
+    
     var body: some View {
         NavigationStack {
             ScrollView {
                 LazyVStack(spacing: 32) {
-                    ForEach(Post.MOCK_POSTS) { post in
+                    ForEach(viewModel.posts) { post in
                         FeedView(post: post)
                     }
                 }

--- a/Zstagram/Core/Feed/View/FeedView.swift
+++ b/Zstagram/Core/Feed/View/FeedView.swift
@@ -6,11 +6,11 @@
 //
 
 import SwiftUI
+import Kingfisher
 
 struct FeedView: View {
     
     let post: Post
-    @State private var isLoading: Bool = true
     
     var body: some View {
         VStack {
@@ -18,7 +18,7 @@ struct FeedView: View {
                 UserImageView(user: user)
             }
             
-            Image(post.imageUrl)
+            KFImage(URL(string: post.imageUrl))
                 .resizable()
                 .scaledToFill()
                 .frame(maxHeight: .infinity)
@@ -65,18 +65,12 @@ struct FeedView: View {
                 caption: post.caption
             )
             
-            Text("\(post.timestamp)")
+            Text("\(post.timestamp.dateValue())")
                 .font(.footnote)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.leading, 10)
                 .padding(.top, 1)
                 .foregroundColor(.gray)
-        }
-        .redacted(reason: isLoading ? .placeholder : [])
-        .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                self.isLoading = false
-            }
         }
     }
 }

--- a/Zstagram/Core/Feed/ViewModel/FeedViewModel.swift
+++ b/Zstagram/Core/Feed/ViewModel/FeedViewModel.swift
@@ -1,0 +1,6 @@
+//
+//  FeedViewModel.swift
+//  Zstagram
+//
+//  Created by Abdelrahman Mohamed on 15.08.2023.
+//

--- a/Zstagram/Core/Feed/ViewModel/FeedViewModel.swift
+++ b/Zstagram/Core/Feed/ViewModel/FeedViewModel.swift
@@ -4,3 +4,33 @@
 //
 //  Created by Abdelrahman Mohamed on 15.08.2023.
 //
+
+import Foundation
+import Firebase
+
+class FeedViewModel: ObservableObject {
+    
+    @Published var posts = [Post]()
+    @Published var isLoading = false
+    
+    init() {
+        Task {
+            try await fetchPosts()
+        }
+    }
+    
+    @MainActor
+    func fetchPosts() async throws {
+        isLoading = true
+        self.posts = try await PostService.fetchPosts()
+        
+        for i in 0 ..< posts.count {
+            let post = posts[i]
+            let ownerUid = post.ownerUid
+            let postUser = try await UserService.fetchUser(withCurrentUId: ownerUid)
+            posts[i].user = postUser
+        }
+        
+        isLoading = false
+    }
+}

--- a/Zstagram/Core/UploadPost/ViewModel/UploadPostViewModel.swift
+++ b/Zstagram/Core/UploadPost/ViewModel/UploadPostViewModel.swift
@@ -67,7 +67,10 @@ class UploadPostViewModel: ObservableObject {
             timestamp: Timestamp()
         )
         
-        guard let encodedPost = try? Firestore.Encoder().encode(post) else { return }
+        guard let encodedPost = try? Firestore.Encoder().encode(post) else {
+            isLoading = false
+            return
+        }
         try await postRef.setData(encodedPost)
         
         isLoading = false

--- a/Zstagram/Services/PostService.swift
+++ b/Zstagram/Services/PostService.swift
@@ -6,3 +6,12 @@
 //
 
 import Foundation
+import Firebase
+
+struct PostService {
+    
+    static func fetchPosts() async throws -> [Post] {
+        let snapshot = try await Firestore.firestore().collection("posts").getDocuments()
+        return snapshot.documents.compactMap({ try? $0.data(as: Post.self) })
+    }
+}

--- a/Zstagram/Services/PostService.swift
+++ b/Zstagram/Services/PostService.swift
@@ -1,0 +1,8 @@
+//
+//  PostService.swift
+//  Zstagram
+//
+//  Created by Abdelrahman Mohamed on 15.08.2023.
+//
+
+import Foundation

--- a/Zstagram/Services/UserService.swift
+++ b/Zstagram/Services/UserService.swift
@@ -10,6 +10,12 @@ import Firebase
 
 struct UserService {
     
+    static func fetchUser(withCurrentUId currentUId: String) async throws -> User {
+        let snapshot = try await Firestore.firestore().collection("users").document(currentUId).getDocument()
+        print("DEBUG: Snapshot data is \(snapshot.data() ?? [:])")
+        return try snapshot.data(as: User.self)
+    }
+    
     static func fetchAllUsers() async throws -> [User] {
         let snapshot = try await Firestore.firestore().collection("users").getDocuments()
         return snapshot.documents.compactMap({ try? $0.data(as: User.self) })


### PR DESCRIPTION
Our App Zstagram now successfully implements fetch feed posts. Retrieving posts from social media platforms has been made possible through an API, and we can easily them for our users with necessary protocols that have been implemented to ensure proper authorization and permissions. Furthermore, I have taken all the measures to prevent potential security risks. In short, our fetch feed posts feature is an excellent addition to our platform, and I am confident in its performance.